### PR TITLE
Package: repository.url should be this repo's link

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/Ecuacion/Pokemon-Showdown-Node-Bot"
+    "url": "https://github.com/Spandamn/Abyssal-Bot.git"
   },
   "bugs": {
     "url": "https://github.com/Ecuacion/Pokemon-Showdown-Node-Bot/issues"


### PR DESCRIPTION
This just allows users to be linked to this repo via '.git' rather than Ecuacion's.
